### PR TITLE
Custom error factory support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/storozhukBM/verifier
+
+go 1.12

--- a/verifier.go
+++ b/verifier.go
@@ -81,7 +81,7 @@ func (v *Verify) WithError(positiveCondition bool, err error) *Verify {
 // That verifies condition passed as first argument.
 // If `positiveCondition == true`, verification will proceed for other checks.
 // If `positiveCondition == false`, internal state will be filled with error,
-// using message argument as format in fmt.Errorf(message, args...).
+// using message argument as format in error factory func(message, args...) (default: fmt.Errorf).
 // After the first failed verification all others won't count and predicates won't be evaluated.
 func (v *Verify) That(positiveCondition bool, message string, args ...interface{}) *Verify {
 	vObj := v
@@ -102,7 +102,7 @@ func (v *Verify) That(positiveCondition bool, message string, args ...interface{
 // That evaluates predicate passed as first argument.
 // If `predicate() == true`, verification will proceed for other checks.
 // If `predicate() == false`, internal state will be filled with error,
-// using message argument as format in fmt.Errorf(message, args...).
+// using message argument as format in error factory func(message, args...) (default: fmt.Errorf).
 // After the first failed verification all others won't count and predicates won't be evaluated.
 func (v *Verify) Predicate(predicate func() bool, message string, args ...interface{}) *Verify {
 	vObj := v


### PR DESCRIPTION
Allows usage errors of custom types. Doesn't break backwards compatibility. Also adds go mod manifest file.

```go
type AccessError struct {
	UserID	int64 `json:"user-id"`
	Message	string `json:"message"`
}

func(err AccessError) Error() string { 
	return fmt.Sprintf("user %d: %s", err.UserID, err.Message) 
}

func NewAccessErr(userID int64) func(string, ...interface{}) error {
	return func(msg string, args ...interface{}) error {
		return AccessError {
			UserID: userID,
			Message: fmt.Sprintf(msg, args...),
		}
	}
}


//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~HTTP handler~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
	verify := verifier.New().WithErrorFactory(NewAccessErr(user.ID))
	
	verify.That(transfer.Destination != "", "transfer destination can't be empty")
	verify.That(transfer.Amount > 0, "transfer amount should be greater than zero")
	verify.That(user.Name != "", "name can't be empty")
	verify.That(user.Age >= 21, "age should be 21 or higher, but yours: %d", person.Age)
	verify.That(user.HasLicense, "customer should have license")
	if verify.GetError() != nil {
		rw.JSON(http.StatusBadRequest, verify.GetError())
	}
//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```